### PR TITLE
Reduce duplicated code and refactor tests

### DIFF
--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -9,7 +9,7 @@ import json
 import string
 import numpy as np
 
-from exceptions import LimeError
+from .exceptions import LimeError
 
 
 def id_generator(size=15):

--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -9,6 +9,8 @@ import json
 import string
 import numpy as np
 
+from exceptions import LimeError
+
 
 def id_generator(size=15):
     """Helper function to generate random div ids. This is useful for embedding
@@ -43,7 +45,11 @@ class DomainMapper(object):
         """
         return exp
 
-    def visualize_instance_html(self, exp, label, div_name, exp_object_name,
+    def visualize_instance_html(self,
+                                exp,
+                                label,
+                                div_name,
+                                exp_object_name,
                                 **kwargs):
         """Produces html for visualizing the instance.
 
@@ -66,26 +72,50 @@ class DomainMapper(object):
 class Explanation(object):
     """Object returned by explainers."""
 
-    def __init__(self, domain_mapper, class_names=None):
-        """Initializer.
+    def __init__(self,
+                 domain_mapper,
+                 mode='classification',
+                 class_names=None):
+        """
+
+        Initializer.
 
         Args:
             domain_mapper: must inherit from DomainMapper class
-            class_names: list of class names
+            type: "classification" or "regression"
+            class_names: list of class names (used for classification)
         """
+        self.mode = mode
         self.domain_mapper = domain_mapper
-        self.class_names = class_names
         self.local_exp = {}
         self.intercept = {}
-        self.top_labels = None
-        self.predict_proba = None
         self.score = None
+        if mode == 'classification':
+            self.class_names = class_names
+            self.top_labels = None
+            self.predict_proba = None
+        elif mode == 'regression':
+            self.class_names = ['negative', 'positive']
+            self.predicted_value = None
+            self.min_value = 0.0
+            self.max_value = 1.0
+            self.dummy_label = 1
+        else:
+            raise LimeError('Invalid explanation mode "{}". '
+                            'Should be either "classification" '
+                            'or "regression".'.format(mode))
 
     def available_labels(self):
-        """Returns the list of labels for which we have any explanations."""
-        if self.top_labels:
-            return list(self.top_labels)
-        return list(self.local_exp.keys())
+        """
+        Returns the list of classification labels for which we have any explanations.
+        """
+        try:
+            assert self.mode == "classification"
+        except AssertionError:
+            raise NotImplementedError('Not supported for regression explanations.')
+        else:
+            ans = self.top_labels if self.top_labels else self.local_exp.keys()
+            return list(ans)
 
     def as_list(self, label=1, **kwargs):
         """Returns the explanation as a list.
@@ -93,13 +123,17 @@ class Explanation(object):
         Args:
             label: desired label. If you ask for a label for which an
                 explanation wasn't computed, will throw an exception.
+                Will be ignored for regression explanations.
             kwargs: keyword arguments, passed to domain_mapper
 
         Returns:
             list of tuples (representation, weight), where representation is
             given by domain_mapper. Weight is a float.
         """
-        return self.domain_mapper.map_exp_ids(self.local_exp[label], **kwargs)
+        label_to_use = label if self.mode == "classification" else self.dummy_label
+        ans = self.domain_mapper.map_exp_ids(self.local_exp[label_to_use], **kwargs)
+
+        return ans
 
     def as_map(self):
         """Returns the map of explanations.
@@ -116,13 +150,14 @@ class Explanation(object):
         Args:
             label: desired label. If you ask for a label for which an
                    explanation wasn't computed, will throw an exception.
+                   Will be ignored for regression explanations.
             kwargs: keyword arguments, passed to domain_mapper
 
         Returns:
             pyplot figure (barchart).
         """
         import matplotlib.pyplot as plt
-        exp = self.as_list(label, **kwargs)
+        exp = self.as_list(label=label, **kwargs)
         fig = plt.figure()
         vals = [x[1] for x in exp]
         names = [x[0] for x in exp]
@@ -132,38 +167,65 @@ class Explanation(object):
         pos = np.arange(len(exp)) + .5
         plt.barh(pos, vals, align='center', color=colors)
         plt.yticks(pos, names)
-        plt.title('Local explanation for class %s' % self.class_names[label])
+        if self.mode == "classification":
+            title = 'Local explanation for class %s' % self.class_names[label]
+        else:
+            title = 'Local explanation'
+        plt.title(title)
         return fig
 
-    def show_in_notebook(self, labels=None, predict_proba=True, **kwargs):
+    def show_in_notebook(self,
+                         labels=None,
+                         predict_proba=True,
+                         show_predicted_value=True,
+                         **kwargs):
         """Shows html explanation in ipython notebook.
 
-           See as_html for parameters.
-           This will throw an error if you don't have IPython installed"""
-        from IPython.core.display import display, HTML
-        display(HTML(self.as_html(labels, predict_proba, **kwargs)))
+        See as_html() for parameters.
+        This will throw an error if you don't have IPython installed"""
 
-    def save_to_file(self, file_path, labels=None, predict_proba=True,
+        from IPython.core.display import display, HTML
+        display(HTML(self.as_html(labels=labels,
+                                  predict_proba=predict_proba,
+                                  show_predicted_value=show_predicted_value,
+                                  **kwargs)))
+
+    def save_to_file(self,
+                     file_path,
+                     labels=None,
+                     predict_proba=True,
+                     show_predicted_value=True,
                      **kwargs):
-        """Saves html explanation to file. See as_html for paramaters.
+        """Saves html explanation to file. .
 
         Params:
             file_path: file to save explanations to
+
+        See as_html() for additional parameters.
+
         """
         file_ = open(file_path, 'w', encoding='utf8')
-        file_.write(self.as_html(labels, predict_proba, **kwargs))
+        file_.write(self.as_html(labels=labels,
+                                 predict_proba=predict_proba,
+                                 show_predicted_value=show_predicted_value,
+                                 **kwargs))
         file_.close()
 
-    def as_html(self, labels=None, predict_proba=True, **kwargs):
+    def as_html(self,
+                labels=None,
+                predict_proba=True,
+                show_predicted_value=True,
+                **kwargs):
         """Returns the explanation as an html page.
 
         Args:
             labels: desired labels to show explanations for (as barcharts).
                 If you ask for a label for which an explanation wasn't
                 computed, will throw an exception. If None, will show
-                explanations for all available labels.
+                explanations for all available labels. (only used for classification)
             predict_proba: if true, add  barchart with prediction probabilities
-                for the top classes.
+                for the top classes. (only used for classification)
+            show_predicted_value: if true, add  barchart with expected value (only used for regression)
             kwargs: keyword arguments, passed to domain_mapper
 
         Returns:
@@ -173,8 +235,9 @@ class Explanation(object):
         def jsonize(x):
             return json.dumps(x)
 
-        if labels is None:
+        if labels is None and self.mode == "classification":
             labels = self.available_labels()
+
         this_dir, _ = os.path.split(__file__)
         bundle = open(os.path.join(this_dir, 'bundle.js'),
                       encoding="utf8").read()
@@ -186,8 +249,9 @@ class Explanation(object):
         out += u'''
         <div class="lime top_div" id="top_div%s"></div>
         ''' % random_id
+
         predict_proba_js = ''
-        if predict_proba:
+        if self.mode == "classifiction" and predict_proba:
             predict_proba_js = u'''
             var pp_div = top_div.append('div')
                                 .classed('lime predict_proba', true);
@@ -196,136 +260,8 @@ class Explanation(object):
             ''' % (jsonize(self.class_names),
                    jsonize(list(self.predict_proba.astype(float))))
 
-        exp_js = '''var exp_div;
-            var exp = new lime.Explanation(%s);
-        ''' % (jsonize(self.class_names))
-        for label in labels:
-            exp = jsonize(self.as_list(label))
-            exp_js += u'''
-            exp_div = top_div.append('div').classed('lime explanation', true);
-            exp.show(%s, %d, exp_div);
-            ''' % (exp, label)
-        raw_js = '''var raw_div = top_div.append('div');'''
-        raw_js += self.domain_mapper.visualize_instance_html(
-                self.local_exp[labels[0]],
-                labels[0],
-                'raw_div',
-                'exp',
-                **kwargs)
-        out += u'''
-        <script>
-        var top_div = d3.select('#top_div%s').classed('lime top_div', true);
-        %s
-        %s
-        %s
-        </script>
-        ''' % (random_id, predict_proba_js, exp_js, raw_js)
-        out += u'</body></html>'
-        return out
-
-
-class RegressionsExplanation(object):
-    """Object returned by explainers."""
-
-    def __init__(self, domain_mapper):
-        """Initializer.
-        Args:
-            domain_mapper: must inherit from DomainMapper class
-            class_names: list of class names
-        """
-        self.domain_mapper = domain_mapper
-        self.local_exp = {}
-        self.intercept = {}
-        self.predicted_value = None
-        self.min_value = 0.0
-        self.max_value = 1.0
-        self.score = None
-        self.label = 1
-
-    def as_list(self, **kwargs):
-        """Returns the explanation as a list.
-        Args:
-            label: desired label. If you ask for a label for which an
-                explanation wasn't computed, will throw an exception.
-            kwargs: keyword arguments, passed to domain_mapper
-        Returns:
-            list of tuples (representation, weight), where representation is
-            given by domain_mapper. Weight is a float.
-        """
-        return self.domain_mapper.map_exp_ids(self.local_exp[self.label], **kwargs)
-
-    def as_map(self):
-        """Returns the map of explanations.
-        Returns:
-            Map from label to list of tuples (feature_id, weight).
-        """
-        return self.local_exp
-
-    def as_pyplot_figure(self, **kwargs):
-        """Returns the explanation as a pyplot figure.
-        Will throw an error if you don't have matplotlib installed
-        Args:
-            kwargs: keyword arguments, passed to domain_mapper
-        Returns:
-            pyplot figure (barchart).
-        """
-        import matplotlib.pyplot as plt
-        exp = self.as_list(**kwargs)
-        fig = plt.figure()
-        vals = [x[1] for x in exp]
-        names = [x[0] for x in exp]
-        vals.reverse()
-        names.reverse()
-        colors = ['green' if x > 0 else 'red' for x in vals]
-        pos = np.arange(len(exp)) + .5
-        plt.barh(pos, vals, align='center', color=colors)
-        plt.yticks(pos, names)
-        plt.title('Local explanation')
-        return fig
-
-    def show_in_notebook(self, show_predicted_value=True, **kwargs):
-        """Shows html explanation in ipython notebook.
-           See as_html for parameters.
-           This will throw an error if you don't have IPython installed"""
-        from IPython.core.display import display, HTML
-        display(HTML(self.as_html(show_predicted_value=show_predicted_value, **kwargs)))
-
-    def save_to_file(self, file_path, labels=None, show_predicted_value=True,
-                     **kwargs):
-        """Saves html explanation to file. See as_html for paramaters.
-        Params:
-            file_path: file to save explanations to
-        """
-        file_ = open(file_path, 'w', encoding='utf8')
-        file_.write(self.as_html(show_predicted_value, **kwargs))
-        file_.close()
-
-    def as_html(self, show_predicted_value=False, **kwargs):
-        """Returns the explanation as an html page.
-        Args:
-            show_predicted_value: if true, add  barchart with expected value
-            kwargs: keyword arguments, passed to domain_mapper
-        Returns:
-            code for an html page, including javascript includes.
-        """
-
-        class_names = ['negative', 'positive']
-
-        def jsonize(x): return json.dumps(x)
-
-        this_dir, _ = os.path.split(__file__)
-        bundle = open(os.path.join(this_dir, 'bundle.js'),
-                      encoding="utf8").read()
-
-        out = u'''<html>
-        <meta http-equiv="content-type" content="text/html; charset=UTF8">
-        <head><script>%s </script></head><body>''' % bundle
-        random_id = id_generator()
-        out += u'''
-        <div class="lime top_div" id="top_div%s"></div>
-        ''' % random_id
         predict_value_js = ''
-        if show_predicted_value:
+        if self.mode == "regression" and show_predicted_value:
             # reference self.predicted_value
             # (svg, predicted_value, min_value, max_value)
             predict_value_js = u'''
@@ -339,17 +275,26 @@ class RegressionsExplanation(object):
 
         exp_js = '''var exp_div;
             var exp = new lime.Explanation(%s);
-        ''' % (jsonize(class_names))
+        ''' % (jsonize(self.class_names))
 
-        exp = jsonize(self.as_list())
-        exp_js += u'''
-        exp_div = top_div.append('div').classed('lime explanation', true);
-        exp.show(%s, %s, exp_div);
-        ''' % (exp, self.label)
+        if self.mode == "classification":
+            for label in labels:
+                exp = jsonize(self.as_list(label))
+                exp_js += u'''
+                exp_div = top_div.append('div').classed('lime explanation', true);
+                exp.show(%s, %d, exp_div);
+                ''' % (exp, label)
+        else:
+            exp = jsonize(self.as_list())
+            exp_js += u'''
+            exp_div = top_div.append('div').classed('lime explanation', true);
+            exp.show(%s, %s, exp_div);
+            ''' % (exp, self.dummy_label)
+
         raw_js = '''var raw_div = top_div.append('div');'''
         raw_js += self.domain_mapper.visualize_instance_html(
-                self.local_exp[self.label],
-                self.label,
+                self.local_exp[labels[0]] if self.mode == "classification" else self.local_exp[self.dummy_label],
+                labels[0] if self.mode == "classification" else self.dummy_label,
                 'raw_div',
                 'exp',
                 **kwargs)
@@ -359,8 +304,9 @@ class RegressionsExplanation(object):
         %s
         %s
         %s
+        %s
         </script>
-        ''' % (random_id, predict_value_js, exp_js, raw_js)
+        ''' % (random_id, predict_proba_js, predict_value_js, exp_js, raw_js)
         out += u'</body></html>'
 
         return out

--- a/lime/explanation.py
+++ b/lime/explanation.py
@@ -83,7 +83,7 @@ class Explanation(object):
         Args:
             domain_mapper: must inherit from DomainMapper class
             type: "classification" or "regression"
-            class_names: list of class names (used for classification)
+            class_names: list of class names (only used for classification)
         """
         self.mode = mode
         self.domain_mapper = domain_mapper

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -13,7 +13,6 @@ import sklearn.preprocessing
 from lime.discretize import QuartileDiscretizer
 from lime.discretize import DecileDiscretizer
 from lime.discretize import EntropyDiscretizer
-from lime.exceptions import LimeError
 from . import explanation
 from . import lime_base
 
@@ -75,7 +74,8 @@ class TableDomainMapper(explanation.DomainMapper):
         weights = [0] * len(self.feature_names)
         for x in exp:
             weights[x[0]] = x[1]
-        out_list = list(zip(self.exp_feature_names, self.feature_values,
+        out_list = list(zip(self.exp_feature_names,
+                            self.feature_values,
                             weights))
         if not show_all:
             out_list = [out_list[x[0]] for x in exp]
@@ -94,15 +94,24 @@ class LimeTabularExplainer(object):
     feature that is 1 when the value is the same as the instance being
     explained."""
 
-    def __init__(self, training_data, training_labels=None, feature_names=None,
-                 categorical_features=None, categorical_names=None,
-                 kernel_width=None, verbose=False, class_names=None,
-                 feature_selection='auto', discretize_continuous=True,
+    def __init__(self,
+                 training_data,
+                 mode="classification",
+                 training_labels=None,
+                 feature_names=None,
+                 categorical_features=None,
+                 categorical_names=None,
+                 kernel_width=None,
+                 verbose=False,
+                 class_names=None,
+                 feature_selection='auto',
+                 discretize_continuous=True,
                  discretizer='quartile'):
         """Init function.
 
         Args:
             training_data: numpy 2d array
+            mode: "classification" or "regression"
             training_labels: labels for training data. Not required, but may be
                 used by discretizer.
             feature_names: list of names (strings) corresponding to the columns
@@ -128,6 +137,7 @@ class LimeTabularExplainer(object):
             discretizer: only matters if discretize_continuous is True. Options
                 are 'quartile', 'decile' or 'entropy'
         """
+        self.mode = mode
         self.feature_names = feature_names
         self.categorical_names = categorical_names
         self.categorical_features = categorical_features
@@ -195,12 +205,18 @@ class LimeTabularExplainer(object):
             self.scaler.scale_[feature] = 1
 
     @staticmethod
-    def round_stuff(x):
-        return ['%.2f' % a for a in x]
+    def convert_and_round(values):
+        return ['%.2f' % v for v in values]
 
-    def explain_instance(self, data_row, classifier_fn, labels=(1,),
-                         top_labels=None, num_features=10, num_samples=5000,
-                         distance_metric='euclidean', model_regressor=None):
+    def explain_instance(self,
+                         data_row,
+                         predict_fn,
+                         labels=(1,),
+                         top_labels=None,
+                         num_features=10,
+                         num_samples=5000,
+                         distance_metric='euclidean',
+                         model_regressor=None):
         """Generates explanations for a prediction.
 
         First, we generate neighborhood data by randomly perturbing features
@@ -210,9 +226,10 @@ class LimeTabularExplainer(object):
 
         Args:
             data_row: 1d numpy array, corresponding to a row
-            classifier_fn: classifier prediction probability function, which
-                takes a numpy array and outputs prediction probabilities.  For
-                ScikitClassifiers , this is classifier.predict_proba.
+            predict_fn: prediction function. For classifiers, this should be a
+                function that takes a numpy array and outputs prediction
+                probabilities. For regressors, this takes a numpy array and
+                returns the predictions. For ScikitClassifiers, this is `classifier.predict_proba()`. For ScikitRegressors, this is `regressor.predict()`.
             labels: iterable with labels to be explained.
             top_labels: if not None, ignore labels and produce explanations for
                 the K labels with highest prediction probabilities, where K is
@@ -237,42 +254,54 @@ class LimeTabularExplainer(object):
                 metric=distance_metric
         ).ravel()
 
-        yss = classifier_fn(inverse)
+        yss = predict_fn(inverse)
 
-        if len(yss.shape) == 1:
-            predict_proba = False
-        elif len(yss.shape) == 2:
-            predict_proba = True
-        else:
-            # raise exceptions.ModelException("Your model is outputting arrays
-            # with {} dimensions".format(len(yss.shape)))
-            raise ValueError("Your model is outputting "
-                             "arrays with {} dimensions".format(len(yss.shape)))
-
-        if not predict_proba:
-            raise NotImplementedError("LIME does not currently support "
-                                      "classifier models without probability "
-                                      "scores. If this conflicts with your "
-                                      "use case, please let us know: "
-                                      "https://github.com/datascienceinc/lime/issues/16")
-
-        elif predict_proba:
-            if self.class_names is None:
-                self.class_names = [str(x) for x in range(yss[0].shape[0])]
+        # for classification, the model needs to provide a list of tuples - classes
+        # along with prediction proabilities
+        if self.mode == "classification":
+            if len(yss.shape) == 1:
+                raise NotImplementedError("LIME does not currently support "
+                                          "classifier models without probability "
+                                          "scores. If this conflicts with your "
+                                          "use case, please let us know: "
+                                          "https://github.com/datascienceinc/lime/issues/16")
+            elif len(yss.shape) == 2:
+                if self.class_names is None:
+                    self.class_names = [str(x) for x in range(yss[0].shape[0])]
+                else:
+                    self.class_names = list(self.class_names)
+                if not np.allclose(yss.sum(axis=1), 1.0):
+                    warnings.warn("""
+                    Prediction probabilties do not sum to 1, and
+                    thus does not constitute a probability space.
+                    Check that you classifier outputs probabilities
+                    (Not log probabilities, or actual class predictions).
+                    """)
             else:
-                self.class_names = list(self.class_names)
-            if not np.allclose(yss.sum(axis=1), 1.0):
-                warnings.warn("""
-                Predictions are not summing to 1, and
-                thus does not constitute a probability space.
-                Check that you classifier outputs probabilities
-                (Not log_probas, or class predictions).
-                """)
+                raise ValueError("Your model outputs "
+                                 "arrays with {} dimensions".format(len(yss.shape)))
+
+        # for regression, the output should be a one-dimensional array of predictions
+        else:
+            yss = predict_fn(inverse)
+            try:
+                assert isinstance(yss, np.ndarray) and len(yss.shape) == 1
+            except AssertionError:
+                raise ValueError("Your model needs to output single-dimensional numpy arrays, not arrays of {} dimensions".format(yss.shape))
+
+            predicted_value = yss[0]
+            min_y = min(yss)
+            max_y = max(yss)
+
+            # add a dimension to be compatible with downstream machinery
+            yss = yss[:, np.newaxis]
+
         feature_names = copy.deepcopy(self.feature_names)
         if feature_names is None:
             feature_names = [str(x) for x in range(data_row.shape[0])]
 
-        values = ['%.2f' % a for a in data_row]
+        values = self.convert_and_round(data_row)
+
         for i in self.categorical_features:
             if self.discretizer is not None and i in self.discretizer.lambdas:
                 continue
@@ -282,6 +311,7 @@ class LimeTabularExplainer(object):
             feature_names[i] = '%s=%s' % (feature_names[i], name)
             values[i] = 'True'
         categorical_features = self.categorical_features
+
         discretized_feature_names = None
         if self.discretizer is not None:
             categorical_features = range(data.shape[1])
@@ -291,24 +321,41 @@ class LimeTabularExplainer(object):
                 discretized_feature_names[f] = self.discretizer.names[f][int(
                         discretized_instance[f])]
 
-        domain_mapper = TableDomainMapper(
-                feature_names, values, scaled_data[0],
-                categorical_features=categorical_features,
-                discretized_feature_names=discretized_feature_names)
+        domain_mapper = TableDomainMapper(feature_names,
+                                          values,
+                                          scaled_data[0],
+                                          categorical_features=categorical_features,
+                                          discretized_feature_names=discretized_feature_names)
         ret_exp = explanation.Explanation(domain_mapper=domain_mapper,
                                           class_names=self.class_names)
-        ret_exp.predict_proba = yss[0]
-        if top_labels:
-            labels = np.argsort(yss[0])[-top_labels:]
-            ret_exp.top_labels = list(labels)
-            ret_exp.top_labels.reverse()
+
+        if self.mode == "classification":
+            ret_exp.predict_proba = yss[0]
+            if top_labels:
+                labels = np.argsort(yss[0])[-top_labels:]
+                ret_exp.top_labels = list(labels)
+                ret_exp.top_labels.reverse()
+        else:
+            ret_exp.predicted_value = predicted_value
+            ret_exp.min_value = min_y
+            ret_exp.max_value = max_y
+            labels = [1]
+
         for label in labels:
             (ret_exp.intercept[label],
              ret_exp.local_exp[label],
-             ret_exp.score) = self.base.explain_instance_with_data(
-                    scaled_data, yss, distances, label, num_features,
-                    model_regressor=model_regressor,
-                    feature_selection=self.feature_selection)
+             ret_exp.score) = self.base.explain_instance_with_data(scaled_data,
+                                                                   yss,
+                                                                   distances,
+                                                                   label,
+                                                                   num_features,
+                                                                   model_regressor=model_regressor,
+                                                                   feature_selection=self.feature_selection)
+
+        if self.mode == "regression":
+            ret_exp.intercept[0] = ret_exp.intercept[1]
+            ret_exp.local_exp[0] = [(i, -1 * j) for i, j in ret_exp.local_exp[1]]
+
         return ret_exp
 
     def __data_inverse(self,
@@ -363,106 +410,6 @@ class LimeTabularExplainer(object):
             inverse[1:] = self.discretizer.undiscretize(inverse[1:])
         inverse[0] = data_row
         return data, inverse
-
-    def explain_regressor_instance(
-            self,
-            data_row,
-            predict_fn,
-            num_features=10,
-            num_samples=5000,
-            distance_metric='euclidean',
-            model_regressor=None,
-            testing=False):
-        """Generates explanations for a prediction.
-        First, we generate neighborhood data by randomly perturbing features
-        from the instance (see __data_inverse). We then learn locally weighted
-        linear models on this neighborhood data to explain changes in the
-        prediction in an interpretable way (see lime_base.py).
-        Args:
-            data_row: 1d numpy array, corresponding to a row
-            predict_fn: prediction function, which
-                takes a numpy array and expected values.  For
-                ScikitRegressors , this is classifier.predict.
-        """
-
-        data, inverse = self.__data_inverse(data_row, num_samples)
-
-        scaled_data = (data - self.scaler.mean_) / self.scaler.scale_
-
-        distances = sklearn.metrics.pairwise_distances(
-                scaled_data,
-                scaled_data[0].reshape(1, -1),
-                metric=distance_metric
-        ).ravel()
-
-        yss = predict_fn(inverse)
-        predicted_value = yss[0]
-        min_y = min(yss)
-        max_y = max(yss)
-
-        if not isinstance(yss, np.ndarray):
-            raise LimeError(
-                    "Your model needs to output numpy arrays")
-
-        # if predictions are a single column, then either the model is a
-        # predict_proba with only a single class (where probabilities
-        # are all one), or the model is predicting the most likely class.
-        #  We will assume it's the latter case, but perhaps we
-        # eventually want to check for the former case.
-        if len(yss.shape) != 1:
-            raise LimeError(
-                    "Your regressor model is outputting arrays"
-                    "with {} dimensions".format(len(yss.shape)))
-
-        # add a dimension
-        yss = yss[:, np.newaxis]
-
-        feature_names = copy.deepcopy(self.feature_names)
-
-        if feature_names is None:
-            feature_names = [str(x) for x in range(data_row.shape[0])]
-
-        values = self.round_stuff(data_row)
-
-        for i in self.categorical_features:
-            if self.discretizer is not None and i in self.discretizer.lambdas:
-                continue
-            name = int(data_row[i])
-            if i in self.categorical_names:
-                name = self.categorical_names[i][name]
-            feature_names[i] = '%s=%s' % (feature_names[i], name)
-            values[i] = 'True'
-        categorical_features = self.categorical_features
-        discretized_feature_names = None
-        if self.discretizer is not None:
-            categorical_features = range(data.shape[1])
-            discretized_instance = self.discretizer.discretize(data_row)
-            discretized_feature_names = copy.deepcopy(feature_names)
-            for f in self.discretizer.names:
-                discretized_feature_names[f] = self.discretizer.names[f][int(
-                        discretized_instance[f])]
-
-        domain_mapper = TableDomainMapper(
-                feature_names, values, scaled_data[0],
-                categorical_features=categorical_features,
-                discretized_feature_names=discretized_feature_names)
-        ret_exp = explanation.RegressionsExplanation(
-                domain_mapper=domain_mapper)
-        ret_exp.predicted_value = predicted_value
-        ret_exp.min_value = min_y
-        ret_exp.max_value = max_y
-
-        (ret_exp.intercept[1],
-         ret_exp.local_exp[1],
-         ret_exp.score) = self.base.explain_instance_with_data(
-                scaled_data, yss, distances, 0, num_features,
-                model_regressor=model_regressor,
-                feature_selection=self.feature_selection)
-
-        ret_exp.intercept[0] = ret_exp.intercept[1]
-        ret_exp.local_exp[0] = [(i, -1 * j) for i, j in ret_exp.local_exp[1]]
-
-        return ret_exp
 
 
 class RecurrentTabularExplainer(LimeTabularExplainer):

--- a/lime/lime_tabular.py
+++ b/lime/lime_tabular.py
@@ -326,7 +326,8 @@ class LimeTabularExplainer(object):
                                           scaled_data[0],
                                           categorical_features=categorical_features,
                                           discretized_feature_names=discretized_feature_names)
-        ret_exp = explanation.Explanation(domain_mapper=domain_mapper,
+        ret_exp = explanation.Explanation(domain_mapper,
+                                          mode=self.mode,
                                           class_names=self.class_names)
 
         if self.mode == "classification":

--- a/lime/tests/test_lime_tabular.py
+++ b/lime/tests/test_lime_tabular.py
@@ -16,60 +16,67 @@ from lime.lime_tabular import LimeTabularExplainer
 
 
 class TestLimeTabular(unittest.TestCase):
-    def test_lime_explainer_bad_regressor(self):
+
+    def setUp(self):
         iris = load_iris()
 
-        train, test, labels_train, labels_test = train_test_split(
-            iris.data, iris.target, train_size=0.80)
+        self.feature_names = iris.feature_names
+        self.target_names = iris.target_names
+
+        (self.train,
+         self.test,
+         self.labels_train,
+         self.labels_test) = train_test_split(iris.data, iris.target, train_size=0.80)
+
+    def test_lime_explainer_bad_regressor(self):
 
         rf = RandomForestClassifier(n_estimators=500)
-        rf.fit(train, labels_train)
+        rf.fit(self.train, self.labels_train)
         lasso = Lasso(alpha=1, fit_intercept=True)
-        i = np.random.randint(0, test.shape[0])
+        i = np.random.randint(0, self.test.shape[0])
         with self.assertRaises(TypeError):
-            explainer = LimeTabularExplainer(
-                train,
-                feature_names=iris.feature_names,
-                class_names=iris.target_names,
-                discretize_continuous=True)
-            exp = explainer.explain_instance(test[i],  # noqa:F841
+            explainer = LimeTabularExplainer(self.train,
+                                             mode="classification",
+                                             feature_names=self.feature_names,
+                                             class_names=self.target_names,
+                                             discretize_continuous=True)
+            exp = explainer.explain_instance(self.test[i],  # noqa:F841
                                              rf.predict_proba,
                                              num_features=2, top_labels=1,
                                              model_regressor=lasso)
 
     def test_lime_explainer_good_regressor(self):
         np.random.seed(1)
-        iris = load_iris()
-
-        train, test, labels_train, labels_test = train_test_split(
-            iris.data, iris.target, train_size=0.80)
 
         rf = RandomForestClassifier(n_estimators=500)
-        rf.fit(train, labels_train)
-        i = np.random.randint(0, test.shape[0])
+        rf.fit(self.train, self.labels_train)
+        i = np.random.randint(0, self.test.shape[0])
 
-        explainer = LimeTabularExplainer(
-            train,
-            feature_names=iris.feature_names,
-            class_names=iris.target_names,
-            discretize_continuous=True)
+        explainer = LimeTabularExplainer(self.train,
+                                         mode="classification",
+                                         feature_names=self.feature_names,
+                                         class_names=self.target_names,
+                                         discretize_continuous=True)
 
-        exp = explainer.explain_instance(test[i], rf.predict_proba,
+        exp = explainer.explain_instance(self.test[i],
+                                         rf.predict_proba,
                                          num_features=2,
                                          model_regressor=LinearRegression())
 
         self.assertIsNotNone(exp)
         keys = [x[0] for x in exp.as_list()]
-        self.assertEquals(1,
-                          sum([1 if 'petal width' in x else 0 for x in keys]),
-                          "Petal Width is a major feature")
-        self.assertEquals(1,
-                          sum([1 if 'petal length' in x else 0 for x in keys]),
-                          "Petal Length is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal width' in x else 0 for x in keys]),
+                         "Petal Width is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal length' in x else 0 for x in keys]),
+                         "Petal Length is a major feature")
 
     def test_lime_explainer_good_regressor_synthetic_data(self):
-        X, y = make_classification(
-            n_samples=1000, n_features=20, n_informative=2, n_redundant=2)
+        X, y = make_classification(n_samples=1000,
+                                   n_features=20,
+                                   n_informative=2,
+                                   n_redundant=2)
 
         rf = RandomForestClassifier(n_estimators=500)
         rf.fit(X, y)
@@ -86,59 +93,53 @@ class TestLimeTabular(unittest.TestCase):
 
     def test_lime_explainer_no_regressor(self):
         np.random.seed(1)
-        iris = load_iris()
-
-        train, test, labels_train, labels_test = train_test_split(
-            iris.data, iris.target, train_size=0.80)
 
         rf = RandomForestClassifier(n_estimators=500)
-        rf.fit(train, labels_train)
-        i = np.random.randint(0, test.shape[0])
+        rf.fit(self.train, self.labels_train)
+        i = np.random.randint(0, self.test.shape[0])
 
-        explainer = LimeTabularExplainer(train,
-                                         feature_names=iris.feature_names,
-                                         class_names=iris.target_names,
+        explainer = LimeTabularExplainer(self.train,
+                                         feature_names=self.feature_names,
+                                         class_names=self.target_names,
                                          discretize_continuous=True)
 
-        exp = explainer.explain_instance(test[i], rf.predict_proba,
+        exp = explainer.explain_instance(self.test[i],
+                                         rf.predict_proba,
                                          num_features=2)
         self.assertIsNotNone(exp)
         keys = [x[0] for x in exp.as_list()]
-        self.assertEquals(1,
-                          sum([1 if 'petal width' in x else 0 for x in keys]),
-                          "Petal Width is a major feature")
-        self.assertEquals(1,
-                          sum([1 if 'petal length' in x else 0 for x in keys]),
-                          "Petal Length is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal width' in x else 0 for x in keys]),
+                         "Petal Width is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal length' in x else 0 for x in keys]),
+                         "Petal Length is a major feature")
 
     def test_lime_explainer_entropy_discretizer(self):
         np.random.seed(1)
-        iris = load_iris()
-
-        train, test, labels_train, labels_test = train_test_split(
-            iris.data, iris.target, train_size=0.80)
 
         rf = RandomForestClassifier(n_estimators=500)
-        rf.fit(train, labels_train)
-        i = np.random.randint(0, test.shape[0])
+        rf.fit(self.train, self.labels_train)
+        i = np.random.randint(0, self.test.shape[0])
 
-        explainer = LimeTabularExplainer(train,
-                                         feature_names=iris.feature_names,
-                                         training_labels=labels_train,
-                                         class_names=iris.target_names,
+        explainer = LimeTabularExplainer(self.train,
+                                         feature_names=self.feature_names,
+                                         class_names=self.target_names,
+                                         training_labels=self.labels_train,
                                          discretize_continuous=True,
                                          discretizer='entropy')
 
-        exp = explainer.explain_instance(test[i], rf.predict_proba,
+        exp = explainer.explain_instance(self.test[i],
+                                         rf.predict_proba,
                                          num_features=2)
         self.assertIsNotNone(exp)
         keys = [x[0] for x in exp.as_list()]
-        self.assertEquals(1,
-                          sum([1 if 'petal width' in x else 0 for x in keys]),
-                          "Petal Width is a major feature")
-        self.assertEquals(1,
-                          sum([1 if 'petal length' in x else 0 for x in keys]),
-                          "Petal Length is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal width' in x else 0 for x in keys]),
+                         "Petal Width is a major feature")
+        self.assertEqual(1,
+                         sum([1 if 'petal length' in x else 0 for x in keys]),
+                         "Petal Length is a major feature")
 
 
 if __name__ == '__main__':

--- a/lime/tests/test_lime_text.py
+++ b/lime/tests/test_lime_text.py
@@ -1,5 +1,6 @@
 import unittest
 
+from sklearn.datasets import fetch_20newsgroups
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.linear_model import Lasso
 from sklearn.metrics import f1_score
@@ -10,8 +11,8 @@ from lime.lime_text import LimeTextExplainer
 
 
 class TestLimeText(unittest.TestCase):
+
     def test_lime_text_explainer_good_regressor(self):
-        from sklearn.datasets import fetch_20newsgroups
         categories = ['alt.atheism', 'soc.religion.christian']
         newsgroups_train = fetch_20newsgroups(subset='train',
                                               categories=categories)
@@ -31,10 +32,9 @@ class TestLimeText(unittest.TestCase):
         exp = explainer.explain_instance(newsgroups_test.data[idx],
                                          c.predict_proba, num_features=6)
         self.assertIsNotNone(exp)
-        self.assertEquals(6, len(exp.as_list()))
+        self.assertEqual(6, len(exp.as_list()))
 
     def test_lime_text_explainer_bad_regressor(self):
-        from sklearn.datasets import fetch_20newsgroups
         newsgroups_train = fetch_20newsgroups(subset='train')
         newsgroups_test = fetch_20newsgroups(subset='test')
         # making class names shorter


### PR DESCRIPTION
- I incorporated the `RegressionExplanation` class into `Explanation` by adding a `mode` variable that's set to either "classification" (the default) or "regression"). 
- I did the same for `explain_regressor_instance()` by incorporating its code into `explain_instance()`. 
- Both `test_lime_tabular.py` and `test_lime_text.py` pass for both python 2.7 and 3.4. I didn't test 3.6.
- I refactored the lime tabular tests to properly use the `setUp()` method of the test fixture in order to avoid extracting the data for each test. I also made sure that we were using `assertEqual()` instead of `assertEquals()` which is deprecated now. 
- I also made a minor import change to the lime text tests. 
- We need to add more tests such that the actual regression code is tested. 